### PR TITLE
Add support for kfpkg, sha256prefix and workaround for #6, add retry for isp comm

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,15 @@
 ```bash
 # Linux or macOS
 python3 kflash.py firmware.bin
+python3 kflash.py -t firmware.bin # Open a Serial Terminal After Finish
 
 # Windows CMD or PowerShell
 python kflash.py firmware.bin
+python kflash.py -t firmware.bin # Open a Serial Terminal After Finish
 
 # Windows Subsystem for Linux
 sudo python3 kflash.py -p /dev/ttyS13 firmware.bin # ttyS13 Stands for the COM13 in Device Manager
+sudo python3 kflash.py -p /dev/ttyS13 -t firmware.bin # Open a Serial Terminal After Finish
 ```
 
 ## Requirments
@@ -25,6 +28,14 @@ sudo python3 kflash.py -p /dev/ttyS13 firmware.bin # ttyS13 Stands for the COM13
  python get-pip.py 
  python -mpip install pyserial
  ```
+---------
+### macOS
+```bash
+# Install Homebrew, an awesome package manager for macOS
+/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)" 
+brew install python
+python3 -mpip3 install pyserial
+```
 ---------
 ### Ubuntu, Debian
 

--- a/kflash.py
+++ b/kflash.py
@@ -693,7 +693,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--port", help="COM Port", default="DEFAULT")
     parser.add_argument("-c", "--chip", help="SPI Flash type, 1 for in-chip, 0 for on-board", default=1)
-    parser.add_argument("-b", "--baudrate", type=int, help="UART baudrate for uploading firmware", default=115200)
+    parser.add_argument("-b", "--baudrate", type=int, help="UART baudrate for uploading firmware", default=2000000)
     parser.add_argument("-l", "--bootloader", help="bootloader bin path", required=False, default=None)
     parser.add_argument("-k", "--key", help="AES key in hex, if you need encrypt your firmware.", required=False, default=None)
     parser.add_argument("-v", "--verbose", help="increase output verbosity", default=False,
@@ -766,7 +766,8 @@ if __name__ == '__main__':
 
     loader.flash_greeting()
 
-    loader.change_baudrate(args.baudrate)
+    if args.baudrate != 115200:
+        loader.change_baudrate(args.baudrate)
 
     loader.init_flash(args.chip)
 

--- a/kflash.py
+++ b/kflash.py
@@ -37,7 +37,7 @@ class AES:
     You generally should not need this. Use the AESModeOfOperation classes
     below instead.'''
 
-    def _compact_word(word):
+    def _compact_word(self, word):
         return (word[0] << 24) | (word[1] << 16) | (word[2] << 8) | word[3]
 
     # Number of rounds by keysize
@@ -151,7 +151,7 @@ class AES:
         a = [0, 0, 0, 0]
 
         # Convert plaintext to (ints ^ key)
-        t = [(AES._compact_word(plaintext[4 * i:4 * i + 4]) ^ self._Ke[0][i]) for i in range(0, 4)]
+        t = [(self._compact_word(plaintext[4 * i:4 * i + 4]) ^ self._Ke[0][i]) for i in range(0, 4)]
 
         # Apply round transforms
         for r in range(1, rounds):
@@ -185,7 +185,7 @@ class AES:
         a = [0, 0, 0, 0]
 
         # Convert ciphertext to (ints ^ key)
-        t = [(AES._compact_word(ciphertext[4 * i:4 * i + 4]) ^ self._Kd[0][i]) for i in range(0, 4)]
+        t = [(self._compact_word(ciphertext[4 * i:4 * i + 4]) ^ self._Kd[0][i]) for i in range(0, 4)]
 
         # Apply round transforms
         for r in range(1, rounds):

--- a/kflash.py
+++ b/kflash.py
@@ -39,8 +39,8 @@ class AES:
     '''Encapsulates the AES block cipher.
     You generally should not need this. Use the AESModeOfOperation classes
     below instead.'''
-
-    def _compact_word(self, word):
+    @staticmethod
+    def _compact_word(word):
         return (word[0] << 24) | (word[1] << 16) | (word[2] << 8) | word[3]
 
     # Number of rounds by keysize
@@ -154,7 +154,7 @@ class AES:
         a = [0, 0, 0, 0]
 
         # Convert plaintext to (ints ^ key)
-        t = [(self._compact_word(plaintext[4 * i:4 * i + 4]) ^ self._Ke[0][i]) for i in range(0, 4)]
+        t = [(AES._compact_word(plaintext[4 * i:4 * i + 4]) ^ self._Ke[0][i]) for i in range(0, 4)]
 
         # Apply round transforms
         for r in range(1, rounds):
@@ -188,7 +188,7 @@ class AES:
         a = [0, 0, 0, 0]
 
         # Convert ciphertext to (ints ^ key)
-        t = [(self._compact_word(ciphertext[4 * i:4 * i + 4]) ^ self._Kd[0][i]) for i in range(0, 4)]
+        t = [(AES._compact_word(ciphertext[4 * i:4 * i + 4]) ^ self._Kd[0][i]) for i in range(0, 4)]
 
         # Apply round transforms
         for r in range(1, rounds):
@@ -693,7 +693,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--port", help="COM Port", default="DEFAULT")
     parser.add_argument("-c", "--chip", help="SPI Flash type, 1 for in-chip, 0 for on-board", default=1)
-    parser.add_argument("-b", "--baudrate", type=int, help="UART baudrate for uploading firmware", default=2000000)
+    parser.add_argument("-b", "--baudrate", type=int, help="UART baudrate for uploading firmware", default=115200)
     parser.add_argument("-l", "--bootloader", help="bootloader bin path", required=False, default=None)
     parser.add_argument("-k", "--key", help="AES key in hex, if you need encrypt your firmware.", required=False, default=None)
     parser.add_argument("-v", "--verbose", help="increase output verbosity", default=False,

--- a/kflash.py
+++ b/kflash.py
@@ -651,7 +651,7 @@ class MAIXLoader:
         # 1. 刷入 flash bootloader
         self.flash_dataframe(data, address=0x80000000)
 
-    def flash_firmware(self, firmware_bin: bytes, aes_key: bytes = None, address_offset = 0, sha256Prefix = False):
+    def flash_firmware(self, firmware_bin: bytes, aes_key: bytes = None, address_offset = 0, sha256Prefix = True):
         #print('[DEBUG] flash_firmware DEBUG: aeskey=', aes_key)
 
         if sha256Prefix == True:

--- a/kflash.py
+++ b/kflash.py
@@ -623,15 +623,15 @@ class MAIXLoader:
 
             out = struct.pack('HH', 0xd4, 0x00) + crc32_checksum + out + chunk
             #print("[$$$$]", binascii.hexlify(out[:32]).decode())
-            iRetryCount = 0
+            retry_count = 0
             while True:
                 try:
                     sent = self.write(out)
                     #print('[INFO]', 'sent', sent, 'bytes', 'checksum', crc32_checksum)
                     self.flash_recv_debug()
                 except:
-                    iRetryCount = iRetryCount + 1
-                    if iRetryCount > 15:
+                    retry_count = retry_count + 1
+                    if retry_count > 15:
                         print(ERROR_MSG,"Error Count Exceeded, Stop Trying",BASH_TIPS['DEFAULT'])
                         sys.exit(1)
                     continue
@@ -720,11 +720,11 @@ if __name__ == '__main__':
     # 1. Greeting.
     print(INFO_MSG,"Trying to Enter the ISP Mode...",BASH_TIPS['DEFAULT'])
     
-    retryCount = 0
+    retry_count = 0
 
     while 1:
-        retryCount = retryCount + 1
-        if retryCount > 15:
+        retry_count = retry_count + 1
+        if retry_count > 15:
             print("\n" + ERROR_MSG,"No vaild Kendryte K210 found in Auto Detect, Check Your Connection or Specify One by"+BASH_TIPS['GREEN']+'`-p '+('/dev/ttyUSB0', 'COM3')[sys.platform == 'win32']+'`',BASH_TIPS['DEFAULT'])
             sys.exit(1)
         try:


### PR DESCRIPTION
Tests are conducted on both KD233 and Dan platform, both are working for following scenarios:
 - KD233 and Dan with a huge file, or small file, the program is consistent with the file.
 - KD233 and Dan with sample kfpkg file, program is consistent and fully functional.
