### PR TITLE
Typo fix: "Requirments" -> "Requirements"

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ sudo python3 kflash.py -p /dev/ttyS13 firmware.bin # ttyS13 Stands for the COM13
 sudo python3 kflash.py -p /dev/ttyS13 -t firmware.bin # Open a Serial Terminal After Finish
 ```
 
-## Requirments
+## Requirements
 
 - Python3
 - PySerial


### PR DESCRIPTION
(Seems like the GitHub editor also modified the white space on the last line.)