### PR TITLE
Fix "Response timeout" #19 due to 3965b6

### DIFF
--- a/kflash.py
+++ b/kflash.py
@@ -433,8 +433,7 @@ class MAIXLoader:
         while 1:
             if time.time() - timeout_init > timeout:
                 print(ERROR_MSG,'Response timeout',BASH_TIPS['DEFAULT'])
-                sys.exit(1)
-                #raise TimeoutError
+                raise TimeoutError
             c = self._port.read(1)
             #sys.stdout.write(binascii.hexlify(c).decode())
             sys.stdout.flush()


### PR DESCRIPTION
Fix "Response timeout" #19 due to https://github.com/kendryte/kflash.py/commit/3965b6c32f4a01378bcfade62579b7e4fad97912